### PR TITLE
Upgrade Support libraries to v23.0.1 and fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ Requirements
 Building
 --------
 
-To build, install and run a debug version, run this from the root of the project:
+To build and install a debug version, run this from the root of the project:
 
-    ./gradlew installRunDebug
+    ./gradlew installDebug

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    final SUPPORT_LIBRARY_VERSION = '23.0.0'
+    final SUPPORT_LIBRARY_VERSION = '23.0.1'
     final DAGGER_VERSION = '2.0.1'
     final HAMCREST_VERSION = '1.3'
     final MOCKITO_VERSION = '1.10.19'
@@ -44,7 +44,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     compile "com.android.support:support-v4:$SUPPORT_LIBRARY_VERSION"
-    compile 'com.android.support:customtabs:23.0.0'
+    compile "com.android.support:customtabs:$SUPPORT_LIBRARY_VERSION"
     compile "com.android.support:appcompat-v7:$SUPPORT_LIBRARY_VERSION"
     compile "com.android.support:cardview-v7:$SUPPORT_LIBRARY_VERSION"
     compile "com.android.support:design:$SUPPORT_LIBRARY_VERSION"


### PR DESCRIPTION
- Upgrade Support libraries to v23.0.1 as v23.0.0 no longer appears
  available.
- Update the Gradle instructions in the documentation to use the
  installDebug task as "installRunDebug" does not exist.
